### PR TITLE
Update video codec for Mac OS X.

### DIFF
--- a/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
+++ b/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
@@ -89,7 +89,7 @@ This time we create a **VideoWriter** object. We should specify the output file 
 
 * In Fedora: DIVX, XVID, MJPG, X264, WMV1, WMV2. (XVID is more preferable. MJPG results in high size video. X264 gives very small size video)
 * In Windows: DIVX (More to be tested and added)
-* In OSX : *(I don't have access to OSX. Can some one fill this?)*
+* In OS X : mp4v (note the lower case, as per `this Stack Overflow post <http://stackoverflow.com/questions/10605163/opencv-videowriter-under-osx-producing-no-output>`_). On OS X, the output extension of ``.mov`` is also preferred.
 
 FourCC code is passed as ``cv2.VideoWriter_fourcc('M','J','P','G')`` or ``cv2.VideoWriter_fourcc(*'MJPG)`` for MJPG.
 


### PR DESCRIPTION
I haven't successfully tested any other video codecs yet, but I found this combination to work, which should help OS X users (like myself) get started. It looks like Python works with QTKit on the Mac, so `.mov` is preferred, and I wasn't actually able to get `.avi` writing to successfully work at all.
